### PR TITLE
Updated UrbanDictionary.random_word to correctly call Word.from_url instead of UrbanDictionary.define on the returned data of the call to http://urbandictionary.com/random.php.

### DIFF
--- a/lib/urban_dictionary.rb
+++ b/lib/urban_dictionary.rb
@@ -20,6 +20,6 @@ module UrbanDictionary
       http.request(req)
     }
 
-    define(rsp['location'])
+    Word.from_url(rsp['location'])
   end
 end


### PR DESCRIPTION
UrbanDictionary.random_word function was incorrectly passing a URL to
the UrbanDictionary.define function. Changed to use Word.from_url
instead since that's what we get back from the HTTP request.
