### PR TITLE
Fix carriage return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - Added support for `-n <number>` or `--definitions=<number>` to limit output
+- Fixed output mangled by carriage returns (`\r`)
 
 ## 1.0.0 - 2016-02-15
 - Fixed broken parsing of Urban Dictionary's new layout

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Specify the output format with `--format`. The default is `plain`; `json` is als
       "entries": [
         {
           "definition": "keepin it real to the fullest and super tight.",
-          "example": "end of the convo\rLuke: aight man, peace\rQ: kool homie, keep it one hundred (100)"
+          "example": "end of the convo\nLuke: aight man, peace\nQ: kool homie, keep it one hundred (100)"
         },
         ...
     }

--- a/lib/urban_dictionary/formatters.rb
+++ b/lib/urban_dictionary/formatters.rb
@@ -2,6 +2,15 @@ require 'multi_json'
 
 module UrbanDictionary
   class Formatter
+    class Util
+      PATTERN = Regexp.compile(/\r\n|\r|\n/)
+      NEW_LINE = "\n"
+
+      def self.convert_linebreaks(str)
+        str.gsub(PATTERN, NEW_LINE)
+      end
+    end
+
     def self.register(name, klass)
       @formatters ||= {}
       if @formatters.include?(name)
@@ -31,9 +40,9 @@ module UrbanDictionary
       output << '-' * word.size
       output << ''
       word.entries.each_with_index do |entry, i|
-        output << "#{i + 1}. #{entry.definition}"
+        output << "#{i + 1}. #{Util.convert_linebreaks(entry.definition)}"
         output << ""
-        output << "Example: #{entry.example}"
+        output << "Example: #{Util.convert_linebreaks(entry.example)}"
         output << ""
         output << ""
       end
@@ -47,8 +56,8 @@ module UrbanDictionary
         :word => word.word,
         :entries => word.entries.map do |entry|
           {
-            :definition => entry.definition,
-            :example => entry.example
+            :definition => Util.convert_linebreaks(entry.definition),
+            :example => Util.convert_linebreaks(entry.example)
           }
         end
       }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,13 @@ module TestHelpers
   def load_fixture(name)
     File.read(File.expand_path("../html/#{name}", __FILE__))
   end
+
+  def mk_word(term, definitions, examples)
+    UrbanDictionary::Word.new(
+      term,
+      Array(definitions).zip(Array(examples)).map {|ea| UrbanDictionary::Entry.new(*ea) }
+    )
+  end
 end
 
 class String

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,22 +5,16 @@ require 'shellwords'
 require 'stringio'
 require 'webmock/rspec'
 
-RSpec.configure do |config|
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
-  config.order = 'random'
-end
-
-module Test
-  def self.load_fixture(name)
-    File.read(File.expand_path("../html/#{name}", __FILE__))
-  end
-
+module TestHelpers
   class IO < StringIO
     def content
       rewind
       read
     end
+  end
+
+  def load_fixture(name)
+    File.read(File.expand_path("../html/#{name}", __FILE__))
   end
 end
 
@@ -31,3 +25,9 @@ class String
   end
 end
 
+RSpec.configure do |config|
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+  config.order = 'random'
+  config.include TestHelpers
+end

--- a/spec/urban_dictionary/cli_spec.rb
+++ b/spec/urban_dictionary/cli_spec.rb
@@ -15,8 +15,8 @@ describe UrbanDictionary::CLI do
   def mk_cli(str, dictionary = nil)
     config = CLI::Config.new(
       :args => str.to_argv,
-      :stdout => Test::IO.new,
-      :stderr => Test::IO.new,
+      :stdout => TestHelpers::IO.new,
+      :stderr => TestHelpers::IO.new,
     )
     config.update(:dictionary, dictionary) unless dictionary.nil?
     cli = CLI.new(config)

--- a/spec/urban_dictionary/cli_spec.rb
+++ b/spec/urban_dictionary/cli_spec.rb
@@ -23,13 +23,6 @@ describe UrbanDictionary::CLI do
     [cli, config]
   end
 
-  def mk_word(term, definitions, examples)
-    UrbanDictionary::Word.new(
-      term,
-      Array(definitions).zip(Array(examples)).map {|ea| UrbanDictionary::Entry.new(*ea) }
-    )
-  end
-
   describe "#run" do
     it "outputs help when called with no arguments" do
       cli, config = mk_cli("")

--- a/spec/urban_dictionary/formatters_spec.rb
+++ b/spec/urban_dictionary/formatters_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe UrbanDictionary::PlainFormatter do
+  let(:formatter) { UrbanDictionary::PlainFormatter }
+
+  describe "#format" do
+    it "converts carriage returns to new lines" do
+      word = mk_word("term", "definition\rwith CR", "example\rwith CR")
+      output = formatter.format(word)
+      expect(output).to include("definition\nwith CR")
+      expect(output).to include("example\nwith CR")
+    end
+  end
+end
+
+describe UrbanDictionary::JsonFormatter do
+  let(:formatter) { UrbanDictionary::JsonFormatter }
+
+  describe "#format" do
+    it "converts carriage returns to new lines" do
+      word = mk_word("term", "definition\rwith CR", "example\rwith CR")
+      output = MultiJson.load(formatter.format(word))
+      expected_output = [
+        {"definition" => "definition\nwith CR", "example" => "example\nwith CR"}
+      ]
+      expect(output["entries"]).to eq(expected_output)
+    end
+  end
+end

--- a/spec/urban_dictionary/word_spec.rb
+++ b/spec/urban_dictionary/word_spec.rb
@@ -24,8 +24,8 @@ describe UrbanDictionary::Word do
   describe "class method" do
     describe "#from_url" do
       let(:url){ "the_url" }
-      let(:html_with_results){ Test.load_fixture("on_fleek_2016-02-15.html") }
-      let(:html_without_results){ Test.load_fixture("sisyphus_2016-02-15.html") }
+      let(:html_with_results){ load_fixture("on_fleek_2016-02-15.html") }
+      let(:html_without_results){ load_fixture("sisyphus_2016-02-15.html") }
 
       it "parses a valid word" do
         word = UrbanDictionary::Word.from_html(html_with_results)


### PR DESCRIPTION
Output for words that contains carriage return characters (`\r`) is output incorrectly in terminals, with the text following the CR character overwriting previous output.
